### PR TITLE
Update to latest ipu2024.3 version

### DIFF
--- a/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20240813.tar.gz
+++ b/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20240813.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f46cfe1d8be8d3c2c5a0fb63fc4d48c7dd1444f34346f0e42ad92c706cb90e79
-size 12879301

--- a/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20240910.tar.gz
+++ b/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20240910.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b7582eac7e9a691356e18b3bdcbc7b2db09494e040ec980a4a5fb6d0da261bf
+size 12879730

--- a/SPECS/microcode_ctl.spec
+++ b/SPECS/microcode_ctl.spec
@@ -2,14 +2,14 @@
 
 %define debug_package %{nil}
 
-%define intel_release 20240813
+%define intel_release 20240910
 %define base_dir Intel-Linux-Processor-Microcode-Data-Files-microcode-%{intel_release}
 
 Summary:        Tool to transform and deploy CPU microcode update for x86.
 Name:           microcode_ctl
 Version:        2.1
 %define base_release 26.xs29
-Release:        %{base_release}.4%{?dist}
+Release:        %{base_release}.5%{?dist}
 Epoch:          2
 Group:          System Environment/Base
 License:        Redistributable, no modification permitted
@@ -67,6 +67,12 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Sep 25 2024 David Morel <david.morel@vates.tech> - 2.1-26.xs29.5
+- Update to the latest version of IPU 2024.3
+- Security updates for: 
+    - INTEL-SA-01103
+    - INTEL-SA-01097
+
 * Fri Aug 16 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 2.1-26.xs29.4
 - Update to the fixed released of IPU 2024.3
 - Intel has re-done the release after we reported that 06-a5-03 was not updated


### PR DESCRIPTION
Intel has published a new tarball, but not made a new IPU release, this update uses the latest one available.