### PR TITLE
Update to publicly released microcode-20250512

### DIFF
--- a/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20250211.tar.gz
+++ b/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20250211.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1da88b51953c9da2e20b5c94b3d7270cf87ea5babcaa56e3d6a5c9eaf11694b3
-size 11844354

--- a/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20250512.tar.gz
+++ b/SOURCES/Intel-Linux-Processor-Microcode-Data-Files-microcode-20250512.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:041af7d2f5791a47c1e914abd7d6255de4d4fc61b0f8e49ada6ee7014bcc3614
+size 14985022

--- a/SPECS/microcode_ctl.spec
+++ b/SPECS/microcode_ctl.spec
@@ -2,14 +2,14 @@
 
 %define debug_package %{nil}
 
-%define intel_release 20250211
+%define intel_release 20250512
 %define base_dir Intel-Linux-Processor-Microcode-Data-Files-microcode-%{intel_release}
 
 Summary:        Tool to transform and deploy CPU microcode update for x86.
 Name:           microcode_ctl
 Version:        2.1
 %define base_release 26.xs29
-Release:        %{base_release}.7%{?dist}
+Release:        %{base_release}.8%{?dist}
 Epoch:          2
 Group:          System Environment/Base
 License:        Redistributable, no modification permitted
@@ -75,6 +75,16 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Tue May 13 2025 David Morel <david.morel@vates.tech> - 2.1-26.xs29.8
+- Update to publicly released microcode-20250512
+- Security updates for:
+    - INTEL-SA-01153
+    - INTEL-SA-01244
+    - INTEL-SA-01247
+    - INTEL-SA-01322
+- Updates for multiple functional issues
+- Upstream doesn't provide updates for older Sapphire Rapids steppings, we kept the last known versions
+
 * Fri Feb 21 2025 David Morel <david.morel@vates.tech> - 2.1-26.xs29.7
 - Update to microcode-20250211 release
 - Security updates for:


### PR DESCRIPTION
- Security updates for:
    - INTEL-SA-01153
    - INTEL-SA-01244
    - INTEL-SA-01247
    - INTEL-SA-01322
- Updates for multiple functional issues
- Intel doesn't provide updates for older Sapphire Rapids steppings, we kept the last known versions